### PR TITLE
ci: Trigger CI only for the main branches

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,7 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 name: Codecov
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   coverage-push:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -3,7 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 name: REUSE Compliance Check
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   reuse:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 name: Build and Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This, for example, avoids running duplicate jobs on PRs.

Signed-off-by: Andrei Gherzan <andrei@gherzan.com>