### PR TITLE
Fix README reference to how to run tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ descending order of their precedence:
 
 ## Tests and Linters
 
-Use the provided `make` script. For tests, a `tests` target is provided: `make
-tests`.
+Use the provided `make` script. For tests, a `test` target is provided: `make
+test`.
 
 Linters can be executed using `make lint`. This make target has additional host
 dependencies on


### PR DESCRIPTION
Very minor, given `Makefile` content as
https://github.com/agherzan/git-mirror-me/blob/1d7f18c7c6f317fdc4a3c9a7f708378527cd4823/Makefile#L9-L10