### PR TITLE
mirror: Fix source definition based on GitHub env variables

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -7,7 +7,6 @@ package mirror
 import (
 	"encoding/json"
 	"errors"
-	"path"
 )
 
 var (
@@ -98,7 +97,7 @@ func (conf *Config) ProcessEnv(logger *Logger, env map[string]string) {
 		} else {
 			url := env["GITHUB_SERVER_URL"]
 			repo := env["GITHUB_REPOSITORY"]
-			conf.SrcRepo = path.Join(url, repo)
+			conf.SrcRepo = url + "/" + repo
 		}
 	}
 

--- a/conf_test.go
+++ b/conf_test.go
@@ -133,11 +133,11 @@ func TestProcessEnv(t *testing.T) {
 		// Source can be set by GitHub CI environment variables.
 		conf := Config{}
 		env := map[string]string{
-			"GITHUB_SERVER_URL": "foo",
-			"GITHUB_REPOSITORY": "bar",
+			"GITHUB_SERVER_URL": "http://github.com",
+			"GITHUB_REPOSITORY": "user/repo",
 		}
 		conf.ProcessEnv(logger, env)
-		if conf.SrcRepo != "foo/bar" {
+		if conf.SrcRepo != "http://github.com/user/repo" {
 			t.Fatal("failed setting source repository from GitHub env variables")
 		}
 	}


### PR DESCRIPTION
We can't use "path" module to join strings using GITHUB_REPOSITORY and
GITHUB_SERVER_URL because "https://" would be converted to "https:/"
breaking authentication detection. Convert it to a simple string
concatenation when using these variables.

Also, make the test catch this issue.

Signed-off-by: Andrei Gherzan <andrei@gherzan.com>